### PR TITLE
Fix the logic of setupmymac

### DIFF
--- a/config/setupmymac
+++ b/config/setupmymac
@@ -371,7 +371,7 @@ if option != :user
   snippet += "PassengerUser #{user}\nPassengerGroup #{group}\n"
 end
 
-# If the passenger_conf doesn't exist or it doesn't match our expected, update/create it.
+# If the passenger_conf doesn't exist or it doesn't match our expected, update or create it.
 if (not File.exist?(passenger_conf)) or (File.exist?(passenger_conf) and File.read(passenger_conf) != snippet)
   sudo do
     color "$ sudo edit #{passenger_conf}"


### PR DESCRIPTION
If the passenger_config does not exist, the second part of the or causes an exception so we need to execute the code if the file does not exist or if it exists, if it doesn't contain the expected content.